### PR TITLE
Add DHCP message-type == 3

### DIFF
--- a/dhcp2mqtt.py
+++ b/dhcp2mqtt.py
@@ -46,7 +46,7 @@ client.loop_start()
 
 def handle_dhcp_packet(packet):
     # just look at discovery packets
-    if DHCP in packet and packet[DHCP].options[0][1] == 1:
+    if DHCP in packet and (packet[DHCP].options[0][1] == 1 or packet[DHCP].options[0][1] == 3):
         # see if the requestor is in the list to monitor
         if packet[Ether].src.lower() in macs:
             print(f"DHCP Discovery from {packet[Ether].src}")

--- a/dhcp2mqtt.py
+++ b/dhcp2mqtt.py
@@ -18,6 +18,7 @@ if MACS_TO_MONITOR is None:
     sys.exit("No MACS_TO_MONITOR environment variable set")
 
 macs = MACS_TO_MONITOR.lower().split(',')
+debounce_log = {}
 
 print(f"Monitoring discover packets from: {macs}")
 
@@ -46,11 +47,13 @@ client.loop_start()
 
 def handle_dhcp_packet(packet):
     # just look at discovery packets
-    if DHCP in packet and (packet[DHCP].options[0][1] == 1 or packet[DHCP].options[0][1] == 3):
+    if DHCP in packet and packet[DHCP].options[0][1] in [1,3]:
         # see if the requestor is in the list to monitor
         if packet[Ether].src.lower() in macs:
-            print(f"DHCP Discovery from {packet[Ether].src}")
-            client.publish(f"{MQTT_TOPIC_PREFIX}/{packet[Ether].src}", 'discover', retain=False)
+            if packet[Ether].src not in debounce_log or debounce_log[packet[Ether].src] < time.time() - 2:
+                debounce_log[packet[Ether].src] = time.time()
+                print(f"DHCP Discovery from {packet[Ether].src}")
+                client.publish(f"{MQTT_TOPIC_PREFIX}/{packet[Ether].src}", 'discover', retain=False)
 
     return
 


### PR DESCRIPTION
When running this script standalone in python 3, I wasn't receiving any DHCP discovery packets.
I did some debugging using scapy's interactive interface and noticed that the message-type I am getting when connecting my Android phone to the network is not 1 (Discovery) but only 3 (Request).

When I leave the network for a longer time, or change the MAC address (from Randomized to Phone MAC or vice versa), it then sends the Discovery packet as well as Request, however if I only leave briefly and then come back to wifi range, only the Request packet is sent. 
For this reason I added the second if check, however this can result in multiple mqtt messages being sent at the same time. 
To mitigate this I added 2 second debounce for each MAC address.

Debug:
```
>>> sniff(filter="udp and (port 67 or 68)")
<Sniffed: TCP:0 UDP:1 ICMP:0 Other:0>
>>> a=_
>>> a[0][DHCP].options[0]
('message-type', 3)
>>> a[0][DHCP].options[0][1]
3

```
I confirmed with Wireshark on my PC that this is the only DHCP packet my phone sends.